### PR TITLE
Update RESTAPI.md

### DIFF
--- a/docs/RESTAPI.md
+++ b/docs/RESTAPI.md
@@ -285,7 +285,7 @@ User-Agent: LibraryApp/1.0.0
 
 #### 4.1.1 회원 목록 조회
 ```yaml
-GET /api/admin/users?page=0%size=10
+GET /api/admin/users
 Authorization: Bearer {JWT_TOKEN}
 Required Role: ADMIN
 
@@ -347,7 +347,7 @@ Response (403 Forbidden):
 
 #### 4.1.2 회원 상세 조회
 ```yaml
-GET /api/v1/users/{user_id}/profile
+GET /api/users/{user_id}/profile
 Authorization: Bearer {JWT_TOKEN}
 Required Role: USER (본인만), ADMIN
 
@@ -554,7 +554,7 @@ Response (200 OK):
 
 #### 4.2.1 상품 목록 조회
 ```yaml
-GET /api/products?page=0&size=10
+GET /api/products
 Authorization: 불필요 (공개 API)
 
 Query Parameters:


### PR DESCRIPTION
API 명세서에서 상품 목록이나 회원 목록을 조회할 때, '?page=0&size=10' 이와 같은 것은 쿼리파라미터라서 API명세서에는 제거해서 작성하였고
회원 전체 목록과 회원 상태 변경과 같은 것은 admin만 접근 가능하므로 '/api/admin' 으로 시작하게 했습니다
회원 상세 정보는 admin과 user(본인)에 해당하는 경우만 열람가능이라 api/admin이나 api/user로 정하기 어려워서 JWT토큰으로 확인할 수 있게 해야겠습니다